### PR TITLE
curly: 'all'

### DIFF
--- a/packages/eslint-config-typescript-react/index.js
+++ b/packages/eslint-config-typescript-react/index.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-unused-vars': 'warn',
+    'curly': 'error',
     'jest/consistent-test-it': ['error', { fn: 'it' }],
     'no-console': 'off',
 


### PR DESCRIPTION
https://eslint.org/docs/rules/curly

```javascript
// NG
if (foo) foo++;

// NG
if (foo)
  foo++;

// OK
if (foo) {
  foo++;
}
```

ルールが無いと表記がブレるのでどちらかに統一したい。

@tomohiro-iwana 
個人的には常に括弧をつけるのが好みですがいかがでしょうか。括弧つけないとたとえば

```javascript
if (foo)
  foo++;
```

この状態で `foo++;` のあとに何らかの処理を続けて書きたくなったときに
```javascript
if (foo)
  foo++;
  bar++;
```

とすると

```javascript
if (foo) {
  foo++;
}
bar++;
```

こう解釈されて意図しない動きをする可能性があったりもする。