### PR TITLE
Disable no-extra-semi

### DIFF
--- a/packages/eslint-config-typescript-react/index.js
+++ b/packages/eslint-config-typescript-react/index.js
@@ -14,6 +14,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'warn',
     curly: 'error',
     'no-console': 'off',
+    'no-extra-semi': 'off',
 
     // TS で interface を export すると no-undef エラーが出る
     // https://github.com/eslint/typescript-eslint-parser/issues/437

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -14,6 +14,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'warn',
     curly: 'error',
     'no-console': 'off',
+    'no-extra-semi': 'off',
 
     // TS で interface を export すると no-undef エラーが出る
     // https://github.com/eslint/typescript-eslint-parser/issues/437

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,7 +2292,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.7.3:
+typescript@^3.7.2, typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
<img width="834" alt="スクリーンショット 2019-12-16 11 14 57" src="https://user-images.githubusercontent.com/13102129/70874499-bb6aab00-1ff5-11ea-9999-75855a3a71b6.png">

こういう `(hoge as any).fuga` みたいな記法に対して、
- prettier は `;` を挿入しようとする
- eslint は `no-extra-semi` に基づいて `;` を削除しようとする

でルールが競合しているので eslint のルールを削除します。