### PR TITLE
feat: remove no-default-export rule

### DIFF
--- a/packages/eslint-config-typescript/cases/no-default-export/README.md
+++ b/packages/eslint-config-typescript/cases/no-default-export/README.md
@@ -1,8 +1,0 @@
-## default export は使わない
-
-### 理由
-
-https://engineering.linecorp.com/ja/blog/you-dont-need-default-export/
-
-1. const で定義した変数の export を 1 行で簡潔に書ける。
-2. 弊社のアプリケーションだと 1 ファイルで複数項目を export することが多い。変数の export は一律 named export に定めるほうがルールの単純さで優れている。

--- a/packages/eslint-config-typescript/cases/no-default-export/ng.case.ts
+++ b/packages/eslint-config-typescript/cases/no-default-export/ng.case.ts
@@ -1,3 +1,0 @@
-const value = 0
-
-export default value

--- a/packages/eslint-config-typescript/cases/no-default-export/ok.case.ts
+++ b/packages/eslint-config-typescript/cases/no-default-export/ok.case.ts
@@ -1,7 +1,0 @@
-const value = 0
-
-export {
-  value
-}
-
-export const value2 = 2

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -23,7 +23,6 @@ module.exports = {
         },
       },
     ],
-    'import/no-default-export': 'warn',
     'no-console': 'off',
     'no-extra-semi': 'off',
 


### PR DESCRIPTION
## やったこと
"import/no-default-export" ルールを削除しました。

## 背景
"import/no-default-export" は named export への移行を推進する目的で v1.0 で私が独断で入れたルールでした。
社内で利用するツールに default export を必要とあるツールがいくつかあり、 warning が noisy なのでこのルールを削除します
e.g. next.js, storybook, etc