### PR TITLE
prefer-const, react/jsx-boolean-value

### DIFF
--- a/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ng.case.tsx
+++ b/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ng.case.tsx
@@ -1,0 +1,4 @@
+const Comp = () => {
+  // eslint-disable-next-line react/react-in-jsx-scope
+  return <input required={true} disabled={false} />
+}

--- a/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ok.case.tsx
+++ b/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ok.case.tsx
@@ -1,0 +1,4 @@
+const Comp = () => {
+  // eslint-disable-next-line react/react-in-jsx-scope
+  return <input required disabled={false} />
+}

--- a/packages/eslint-config-typescript-react/index.js
+++ b/packages/eslint-config-typescript-react/index.js
@@ -3,6 +3,7 @@ module.exports = {
   plugins: ['react', 'react-hooks'],
   rules: {
     'react/display-name': 'off',
+    'react/jsx-boolean-value': 'error',
     'react/jsx-curly-brace-presence': ['error', { props: 'always' }],
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -14,7 +14,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'warn',
     curly: 'error',
     'func-style': 'warn',
-    'prefer-const': 'warn',
+    'prefer-const': 'error',
     'import/order': [
       'error',
       {


### PR DESCRIPTION
## やったこと
- [prefer-const](https://eslint.org/docs/rules/prefer-const) の severity を 'warn' から 'error' に格上げ
  warn には強制力が無いのでルール作るなら基本的に error にしておきたい気持ち。現状 prefer-const が徹底されてるので 'error' に上げても特に問題起きないはず。
- [react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) を有効化
  2 種類書き方があると迷うので lint で矯正したい

## OK
`<input required />`

## NG
`<input required={true} />` 