### PR TITLE
feat: "react/jsx-boolean-value": "always"

### DIFF
--- a/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ng.case.tsx
+++ b/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ng.case.tsx
@@ -1,4 +1,4 @@
 const Comp = () => {
   // eslint-disable-next-line react/react-in-jsx-scope
-  return <input required={true} disabled={false} />
+  return <input required disabled={false} />
 }

--- a/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ok.case.tsx
+++ b/packages/eslint-config-typescript-react/cases/jsx-boolean-value/ok.case.tsx
@@ -1,4 +1,4 @@
 const Comp = () => {
   // eslint-disable-next-line react/react-in-jsx-scope
-  return <input required disabled={false} />
+  return <input required={true} disabled={false} />
 }

--- a/packages/eslint-config-typescript-react/index.js
+++ b/packages/eslint-config-typescript-react/index.js
@@ -3,7 +3,7 @@ module.exports = {
   plugins: ['react', 'react-hooks'],
   rules: {
     'react/display-name': 'off',
-    'react/jsx-boolean-value': 'error',
+    'react/jsx-boolean-value': ['error', 'always'],
     'react/jsx-curly-brace-presence': ['error', { props: 'always' }],
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
## 変更理由

- true と false で構造が一致するほうが一貫性がある
- 値の指定漏れがなくなる( `<Comp loading={loading} />` と書くつもりで `<Comp loading />` にしてしまうミスがなくなる )
- IDE 補完時の書き味の問題（IDE で props を入力補完すると `loading={}` まで入力されるので、true を指定するにはここから文字を消す作業が発生する）